### PR TITLE
fixed crash if entity doesn't have a sound table defined

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -414,7 +414,7 @@ function mobkit.animate(self,anim)
 end
 
 function mobkit.make_sound(self, sound)
-	local spec = self.sounds[sound]
+	local spec = self.sounds and self.sounds[sound]
 	local param_table = {object=self.object}
 	
 	if type(spec) == 'table' then


### PR DESCRIPTION
Fixes this crash reported by Imk by checking if self.sounds is nil before indexing it

` 2019-11-07 02:29:48: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'default' in callback luaentity_Step(): /home/imk/minetest/bin/../mods/mobkit/init.lua:417: attempt to index field 'sounds' (a nil value)
2019-11-07 02:29:48: ERROR[Main]: stack traceback:
2019-11-07 02:29:48: ERROR[Main]:       /home/imk/minetest/bin/../mods/mobkit/init.lua:417: in function 'make_sound'
2019-11-07 02:29:48: ERROR[Main]:       ...mk/minetest/bin/../mods/petz/petz/api/api_on_die.lua:51: in function 'on_die'
2019-11-07 02:29:48: ERROR[Main]:       ...k/minetest/bin/../mods/petz/petz/misc/behaviours.lua:609: in function 'logic'
2019-11-07 02:29:48: ERROR[Main]:       /home/imk/minetest/bin/../mods/mobkit/init.lua:932: in function 'stepfunc'
2019-11-07 02:29:48: ERROR[Main]:       ...inetest/bin/../mods/petz/petz/petz/turtle_mobkit.lua:73: in function <...inetest/bin/../mods/petz/petz/petz/turtle_mobkit.lua:72> `