### PR TITLE
fix crash with mobkit.make_sound in 5.3-dev

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -444,6 +444,7 @@ function mobkit.make_sound(self, sound)
 		param_table.gain = in_range(spec.gain)
 		param_table.fade = in_range(spec.fade)
 		param_table.pitch = in_range(spec.pitch)
+		return minetest.sound_play(spec.name)
 	end
 	return minetest.sound_play(spec, param_table)
 end

--- a/init.lua
+++ b/init.lua
@@ -444,7 +444,7 @@ function mobkit.make_sound(self, sound)
 		param_table.gain = in_range(spec.gain)
 		param_table.fade = in_range(spec.fade)
 		param_table.pitch = in_range(spec.pitch)
-		return minetest.sound_play(spec.name)
+		return minetest.sound_play(spec.name, param_table)
 	end
 	return minetest.sound_play(spec, param_table)
 end


### PR DESCRIPTION
MT 5.3 checks types of values in SimpleSoundSpec tables in minetest.sound_play. This breaks mobkit's feature of passing ranges in sound definitions in `mobkit.make_sound`, resulting in a crash with a message like this:
`AsyncErr: ServerThread::run Lua: Invalid field "gain" (expected number got table).`

To recreate this crash, install [Markov Macaws](https://notabug.org/NetherEran/markov_macaws) on MT 5.3 dev-cb9a44e (a slightly older build like sfan5's most recent one might also work) and the current mobkit master. Then spawn a parrot using `/spawnentity markov_macaws:macaw`. Then wait a little for the parrot to try to make a sound.

This PR fixes this issue by always passing a string as SimpleSoundSpec and leaving the other stuff to the sound parameter table.
