### PR TITLE
add nil check to fix crash

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1148,7 +1148,9 @@ function mobkit.lq_fallover(self)
 		end
 		zrot=zrot+pi*0.05
 		local rot = self.object:get_rotation()
-		self.object:set_rotation({x=rot.x,y=rot.y,z=zrot})
+		if rot then
+			self.object:set_rotation({x=rot.x,y=rot.y,z=zrot})
+		end
 		if zrot >= pi*0.5 then return true end
 	end
 	mobkit.queue_low(self,func)


### PR DESCRIPTION
Caveats:
I'm not entirely sure why `:get_rotation()` is sometimes returning `nil`, but I'm not the only one to get a crash because it sometimes is. I'm suspecting it has to do w/ something w/ minetest 5.3.0+. I don't know enough about this mod to say if skipping the call to `set_rotation()` won't have any important consequences, but my intuition says it won't. 

Example crash stacktrace:
```
2020-09-01 04:34:03: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'default' in callback luaentity_Step(): .../flux/.minetest/worlds/ta_like/worldmods/mobkit/init.lua:1151: attempt to index local 'rot' (a nil value)
2020-09-01 04:34:03: ERROR[Main]: stack traceback:
2020-09-01 04:34:03: ERROR[Main]:       .../flux/.minetest/worlds/ta_like/worldmods/mobkit/init.lua:1151: in function 'func'
2020-09-01 04:34:03: ERROR[Main]:       .../flux/.minetest/worlds/ta_like/worldmods/mobkit/init.lua:741: in function 'execute_queues'
2020-09-01 04:34:03: ERROR[Main]:       .../flux/.minetest/worlds/ta_like/worldmods/mobkit/init.lua:959: in function 'stepfunc'
2020-09-01 04:34:03: ERROR[Main]:       ...worlds/ta_like/worldmods/paleotest/mobs/velociraptor.lua:271: in function 'func'
2020-09-01 04:34:03: ERROR[Main]:       /usr/share/minetest/builtin/profiler/instrumentation.lua:106: in function </usr/share/minetest/builtin/profiler/instrumentation.lua:100>
```