### PR TITLE
force delete entities with memories by negative timeouts

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -794,7 +794,8 @@ function mobkit.actfunc(self, staticdata, dtime_s)
 		if #self.textures > 1 then self.texture_no = random(#self.textures) end
 	end
 	
-	if self.timeout and self.timeout>0 and dtime_s > self.timeout and next(self.memory)==nil then
+	if self.timeout and ((self.timeout>0 and dtime_s > self.timeout and next(self.memory)==nil) or
+	                     (self.timeout<0 and dtime_s > abs(self.timeout))) then
 		self.object:remove()
 	end
 	


### PR DESCRIPTION
This took me several months until I found out what was the problem on my server Lilly.
Finally I found in your dokumentation that entities get not deleted by the actfunc and their
timeout value if they saved something in their memory before.

This grew up to a problem on my server and using aerotest mod. The eagles use memory function
to save hunger and other bio data. But because of landscape they sometimes disappear from ABR.
(that biodata is not **that** important)

They never got deleted, because of their memory and on the other side they keep on spawning and
adding more to the unloaded area.

This can grow to bigger problem for a server which is not restarted every day (eagles are static_save = false)
After a day I had server CPUtime of 50% busy without a single player online.

What I changed is that entities with negative timeout are always deleted, even if they have memories.
Everything else is untouched.

Now modders can chose:

timeout > 0     deleted after timeout and inactivity but not when having memory stored
timeout = 0    never deleted
timeout < 0    force delete after inactivity and timout